### PR TITLE
Fixed logical bug in spinnycube example

### DIFF
--- a/src/spinnycube/spinnycube.cpp
+++ b/src/spinnycube/spinnycube.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2015 Graham Sellers
+ * Copyright Â© 2012-2015 Graham Sellers
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -163,6 +163,8 @@ class singlepoint_app : public sb7::application
 
         glEnable(GL_DEPTH_TEST);
         glDepthFunc(GL_LEQUAL);
+        
+        onResize(info.windowWidth, info.windowHeight);
     }
 
     virtual void render(double currentTime)


### PR DESCRIPTION
Spinnycube example code doesn't display any animation unless window is manually re-sized. I'm forcing projection matrix calculation at startup to render cube correctly.

@grahamsellers for your eyes please.
