### PR TITLE
Calls to glUniform*() wrongly assume uniform variable is at location 0

### DIFF
--- a/src/dispmap/dispmap.cpp
+++ b/src/dispmap/dispmap.cpp
@@ -123,9 +123,9 @@ public:
         {
             switch (key)
             {
-                case GLFW_KEY_KP_ADD: dmap_depth += 0.1f;
+                case GLFW_KEY_EQUAL: dmap_depth += 0.1f;
                     break;
-                case GLFW_KEY_KP_SUBTRACT: dmap_depth -= 0.1f;
+                case GLFW_KEY_MINUS: dmap_depth -= 0.1f;
                     break;
                 case 'F': enable_fog = !enable_fog;
                     break;

--- a/src/dispmap/dispmap.cpp
+++ b/src/dispmap/dispmap.cpp
@@ -123,9 +123,9 @@ public:
         {
             switch (key)
             {
-                case GLFW_KEY_EQUAL: dmap_depth += 0.1f;
+                case GLFW_KEY_KP_ADD: dmap_depth += 0.1f;
                     break;
-                case GLFW_KEY_MINUS: dmap_depth -= 0.1f;
+                case GLFW_KEY_KP_SUBTRACT: dmap_depth -= 0.1f;
                     break;
                 case 'F': enable_fog = !enable_fog;
                     break;

--- a/src/dispmap/dispmap.cpp
+++ b/src/dispmap/dispmap.cpp
@@ -123,9 +123,13 @@ public:
         {
             switch (key)
             {
-                case GLFW_KEY_KP_ADD: dmap_depth += 0.1f;
+                case GLFW_KEY_KP_ADD:
+                case GLFW_KEY_EQUAL:
+                    dmap_depth += 0.1f;
                     break;
-                case GLFW_KEY_KP_SUBTRACT: dmap_depth -= 0.1f;
+                case GLFW_KEY_KP_SUBTRACT:
+                case GLFW_KEY_MINUS:
+                    dmap_depth -= 0.1f;
                     break;
                 case 'F': enable_fog = !enable_fog;
                     break;

--- a/src/gsquads/gsquads.cpp
+++ b/src/gsquads/gsquads.cpp
@@ -140,10 +140,10 @@ public:
             case '2':
                     mode = key - '1';
                 break;
-            case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                 vid_offset++;
                 break;
-            case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                 vid_offset--;
                 break;
             case 'P': paused = !paused;

--- a/src/gsquads/gsquads.cpp
+++ b/src/gsquads/gsquads.cpp
@@ -141,9 +141,11 @@ public:
                     mode = key - '1';
                 break;
             case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                 vid_offset++;
                 break;
             case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                 vid_offset--;
                 break;
             case 'P': paused = !paused;

--- a/src/gsquads/gsquads.cpp
+++ b/src/gsquads/gsquads.cpp
@@ -140,10 +140,10 @@ public:
             case '2':
                     mode = key - '1';
                 break;
-            case GLFW_KEY_EQUAL:
+            case GLFW_KEY_KP_ADD:
                 vid_offset++;
                 break;
-            case GLFW_KEY_MINUS:
+            case GLFW_KEY_KP_SUBTRACT:
                 vid_offset--;
                 break;
             case 'P': paused = !paused;

--- a/src/hdrbloom/hdrbloom.cpp
+++ b/src/hdrbloom/hdrbloom.cpp
@@ -312,9 +312,11 @@ public:
                     paused = !paused;
                 break;
             case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                     exposure *= 1.1f;
                 break;
             case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrbloom/hdrbloom.cpp
+++ b/src/hdrbloom/hdrbloom.cpp
@@ -311,10 +311,10 @@ public:
             case 'P':
                     paused = !paused;
                 break;
-            case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                     exposure *= 1.1f;
                 break;
-            case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrbloom/hdrbloom.cpp
+++ b/src/hdrbloom/hdrbloom.cpp
@@ -311,10 +311,10 @@ public:
             case 'P':
                     paused = !paused;
                 break;
-            case GLFW_KEY_EQUAL:
+            case GLFW_KEY_KP_ADD:
                     exposure *= 1.1f;
                 break;
-            case GLFW_KEY_MINUS:
+            case GLFW_KEY_KP_SUBTRACT:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrexposure/hdrexposure.cpp
+++ b/src/hdrexposure/hdrexposure.cpp
@@ -161,10 +161,10 @@ public:
 
         switch (key)
         {
-            case GLFW_KEY_EQUAL:
+            case GLFW_KEY_KP_ADD:
                     exposure *= 1.1f;
                 break;
-            case GLFW_KEY_MINUS:
+            case GLFW_KEY_KP_SUBTRACT:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrexposure/hdrexposure.cpp
+++ b/src/hdrexposure/hdrexposure.cpp
@@ -162,9 +162,11 @@ public:
         switch (key)
         {
             case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                     exposure *= 1.1f;
                 break;
             case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrexposure/hdrexposure.cpp
+++ b/src/hdrexposure/hdrexposure.cpp
@@ -161,10 +161,10 @@ public:
 
         switch (key)
         {
-            case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                     exposure *= 1.1f;
                 break;
-            case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrexposure/hdrexposure.cpp
+++ b/src/hdrexposure/hdrexposure.cpp
@@ -121,6 +121,7 @@ public:
         glAttachShader(program, fs);
 
         glLinkProgram(program);
+        exposure_location = glGetUniformLocation(program, "exposure");
 
         glGenVertexArrays(1, &vao);
         glBindVertexArray(vao);
@@ -142,7 +143,7 @@ public:
         glBindTexture(GL_TEXTURE_2D, texture);
         glUseProgram(program);
         glViewport(0, 0, info.windowWidth, info.windowHeight);
-        glUniform1f(0, exposure);
+        glUniform1f(exposure_location, exposure);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
         char buffer[1024];
@@ -174,6 +175,7 @@ private:
     GLuint      program;
     GLuint      vao;
     float       exposure;
+    GLint       exposure_location;
     sb7::text_overlay overlay;
 };
 

--- a/src/hdrtonemap/hdrtonemap.cpp
+++ b/src/hdrtonemap/hdrtonemap.cpp
@@ -145,9 +145,11 @@ public:
                     mode = (mode + 1) % 3;
                 break;
             case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                     exposure *= 1.1f;
                 break;
             case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrtonemap/hdrtonemap.cpp
+++ b/src/hdrtonemap/hdrtonemap.cpp
@@ -144,10 +144,10 @@ public:
             case 'M':
                     mode = (mode + 1) % 3;
                 break;
-            case GLFW_KEY_EQUAL:
+            case GLFW_KEY_KP_ADD:
                     exposure *= 1.1f;
                 break;
-            case GLFW_KEY_MINUS:
+            case GLFW_KEY_KP_SUBTRACT:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/hdrtonemap/hdrtonemap.cpp
+++ b/src/hdrtonemap/hdrtonemap.cpp
@@ -144,10 +144,10 @@ public:
             case 'M':
                     mode = (mode + 1) % 3;
                 break;
-            case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                     exposure *= 1.1f;
                 break;
-            case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                     exposure /= 1.1f;
                 break;
         }

--- a/src/ktxview/ktxview.cpp
+++ b/src/ktxview/ktxview.cpp
@@ -111,6 +111,7 @@ public:
         glAttachShader(program, fs);
 
         glLinkProgram(program);
+        exposure_location = glGetUniformLocation(program, "exposure");
 
         glGenVertexArrays(1, &vao);
         glBindVertexArray(vao);
@@ -130,7 +131,7 @@ public:
 
         glUseProgram(program);
         glViewport(0, 0, info.windowWidth, info.windowHeight);
-        glUniform1f(0, (float)(sin(t) * 16.0 + 16.0));
+        glUniform1f(exposure_location, (float)(sin(t) * 16.0 + 16.0));
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }
 
@@ -138,6 +139,7 @@ private:
     GLuint      texture;
     GLuint      program;
     GLuint      vao;
+    GLint       exposure_location;
 };
 
 DECLARE_MAIN(simpletexture_app);

--- a/src/raytracer/raytracer.cpp
+++ b/src/raytracer/raytracer.cpp
@@ -447,11 +447,13 @@ void raytracer_app::onKey(int key, int action)
         switch (key)
         {
             case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                 max_depth++;
                 if (max_depth > MAX_RECURSION_DEPTH)
                     max_depth = MAX_RECURSION_DEPTH;
                 break;
             case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                 max_depth--;
                 if (max_depth < 1)
                     max_depth = 1;

--- a/src/raytracer/raytracer.cpp
+++ b/src/raytracer/raytracer.cpp
@@ -446,12 +446,12 @@ void raytracer_app::onKey(int key, int action)
     {
         switch (key)
         {
-            case GLFW_KEY_KP_ADD:
+            case GLFW_KEY_EQUAL:
                 max_depth++;
                 if (max_depth > MAX_RECURSION_DEPTH)
                     max_depth = MAX_RECURSION_DEPTH;
                 break;
-            case GLFW_KEY_KP_SUBTRACT:
+            case GLFW_KEY_MINUS:
                 max_depth--;
                 if (max_depth < 1)
                     max_depth = 1;

--- a/src/raytracer/raytracer.cpp
+++ b/src/raytracer/raytracer.cpp
@@ -446,12 +446,12 @@ void raytracer_app::onKey(int key, int action)
     {
         switch (key)
         {
-            case GLFW_KEY_EQUAL:
+            case GLFW_KEY_KP_ADD:
                 max_depth++;
                 if (max_depth > MAX_RECURSION_DEPTH)
                     max_depth = MAX_RECURSION_DEPTH;
                 break;
-            case GLFW_KEY_MINUS:
+            case GLFW_KEY_KP_SUBTRACT:
                 max_depth--;
                 if (max_depth < 1)
                     max_depth = 1;

--- a/src/springmass/springmass.cpp
+++ b/src/springmass/springmass.cpp
@@ -229,9 +229,9 @@ private:
                     break;
                 case 'P': draw_points = !draw_points;
                     break;
-                case GLFW_KEY_KP_ADD: iterations_per_frame++;
+                case GLFW_KEY_EQUAL: iterations_per_frame++;
                     break;
-                case GLFW_KEY_KP_SUBTRACT: iterations_per_frame--;
+                case GLFW_KEY_MINUS: iterations_per_frame--;
                     break;
             }
         }

--- a/src/springmass/springmass.cpp
+++ b/src/springmass/springmass.cpp
@@ -229,9 +229,13 @@ private:
                     break;
                 case 'P': draw_points = !draw_points;
                     break;
-                case GLFW_KEY_KP_ADD: iterations_per_frame++;
+                case GLFW_KEY_KP_ADD:
+                case GLFW_KEY_EQUAL:
+                    iterations_per_frame++;
                     break;
-                case GLFW_KEY_KP_SUBTRACT: iterations_per_frame--;
+                case GLFW_KEY_KP_SUBTRACT:
+                case GLFW_KEY_MINUS:
+                    iterations_per_frame--;
                     break;
             }
         }

--- a/src/springmass/springmass.cpp
+++ b/src/springmass/springmass.cpp
@@ -229,9 +229,9 @@ private:
                     break;
                 case 'P': draw_points = !draw_points;
                     break;
-                case GLFW_KEY_EQUAL: iterations_per_frame++;
+                case GLFW_KEY_KP_ADD: iterations_per_frame++;
                     break;
-                case GLFW_KEY_MINUS: iterations_per_frame--;
+                case GLFW_KEY_KP_SUBTRACT: iterations_per_frame--;
                     break;
             }
         }

--- a/src/tesssubdivmodes/tesssubdivmodes.cpp
+++ b/src/tesssubdivmodes/tesssubdivmodes.cpp
@@ -180,6 +180,7 @@ public:
             glAttachShader(program[i], tes);
             glAttachShader(program[i], fs);
             glLinkProgram(program[i]);
+            tess_level_location[i] = glGetUniformLocation(program[i], "tess_level");
 
             glDeleteShader(vs);
             glDeleteShader(tcs);
@@ -200,8 +201,8 @@ public:
         glClearBufferfv(GL_COLOR, 0, black);
 
         glUseProgram(program[program_index]);
-        // glUniform1f(0, sinf((float)currentTime) * 5.0f + 6.0f);
-        glUniform1f(0, 5.3f);
+        // glUniform1f(tess_level_location[program_index], sinf((float)currentTime) * 5.0f + 6.0f);
+        glUniform1f(tess_level_location[program_index], 5.3f);
         glDrawArrays(GL_PATCHES, 0, 4);
     }
 
@@ -232,6 +233,7 @@ private:
     GLuint          program[3];
     int             program_index;
     GLuint          vao;
+    GLint           tess_level_location[3];
 };
 
 DECLARE_MAIN(tesssubdivmodes_app)

--- a/src/wrapmodes/wrapmodes.cpp
+++ b/src/wrapmodes/wrapmodes.cpp
@@ -96,6 +96,7 @@ public:
         glAttachShader(program, fs);
 
         glLinkProgram(program);
+        offset_location = glGetUniformLocation(program, "offset");
 
         glGenVertexArrays(1, &vao);
         glBindVertexArray(vao);
@@ -127,7 +128,7 @@ public:
 
         for (int i = 0; i < 4; i++)
         {
-            glUniform2fv(0, 1, &offsets[i * 2]);
+            glUniform2fv(offset_location, 1, &offsets[i * 2]);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapmodes[i]);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapmodes[i]);
 
@@ -139,6 +140,7 @@ private:
     GLuint      texture;
     GLuint      program;
     GLuint      vao;
+    GLint       offset_location;
 };
 
 DECLARE_MAIN(wrapmodes_app);


### PR DESCRIPTION
These changes fix problems on 4 of the examples (see below) with the
following hardware & drivers on Windows 8.1 Pro x64:
- NVIDIA GeForce GTX 650 Ti with driver 353.30
- Intel HD 4400 with driver 10.18.14.4206 (OpenGL 4.3)

`hdrexposure`
- NVIDIA: no output, and the following error:
  `GL_INVALID_OPERATION error generated. Wrong component type or count.`

`ktxview`
- NVIDIA:
  `GL_INVALID_OPERATION error generated. Wrong component type or count.`
- Intel: no output, and the following error:
  `Error has been generated. GL error GL_INVALID_OPERATION: GL error
  GL_INVALID_OPERATION: mismatched type setting uniform "s" in program 1,
  "" using shaders, 2, "", 3, ""`

`tesssubdivmodes`
- NVIDIA: no output, and the following error:
  `GL_INVALID_OPERATION error generated. Wrong component type or count.`

`wrapmodes`
- NVIDIA: wrong output, and the following error:
  `GL_INVALID_OPERATION error generated. Wrong component type or count.`

Wrong:
![wrapmodes_location0](https://cloud.githubusercontent.com/assets/4930759/9251518/ff0134b2-41a9-11e5-896d-7a108aafda97.png)
Right:
![wrapmodes_glgetuniformlocation](https://cloud.githubusercontent.com/assets/4930759/9251530/09e3ec3a-41aa-11e5-887f-60e8b2164e91.png)
