### PR TITLE
Corrected OS detection in preprocessor

### DIFF
--- a/include/sb7.h
+++ b/include/sb7.h
@@ -177,7 +177,7 @@ public:
 
     virtual void init()
     {
-        strcpy(info.title, "OpenGL SuperBible Example");
+        strcpy_s(info.title, "OpenGL SuperBible Example");
         info.windowWidth = 800;
         info.windowHeight = 600;
 #ifdef __APPLE__

--- a/include/sb7.h
+++ b/include/sb7.h
@@ -26,7 +26,7 @@
 #ifndef __SB7_H__
 #define __SB7_H__
 
-#ifdef WIN32
+#ifdef _WIN32
     #pragma once
     #define _CRT_SECURE_NO_WARNINGS 1
 


### PR DESCRIPTION
Corrected the OS dection in Preprocessor
It should be #ifdef _WIN32 instead of #ifdef WIN32
