### PR TITLE
Fix linking error on ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(COMMON_LIBS sb7 optimized glfw3 debug glfw3_d ${GLFW_LIBRARIES} ${OPENGL_LIB
 elseif (UNIX)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLFW REQUIRED glfw3)
-set(COMMON_LIBS sb7 glfw3 X11 Xrandr Xinerama Xi Xxf86vm Xcursor GL rt dl)
+set(COMMON_LIBS sb7 ${GLFW_LIBRARIES} X11 Xrandr Xinerama Xi Xxf86vm Xcursor GL rt dl)
 else()
 set(COMMON_LIBS sb7)
 endif()


### PR DESCRIPTION
using the cmake variable for glfw fixes the following linking error:

Linking CXX executable ../bin/alienrain
/usr/bin/ld: cannot find -lglfw3
collect2: error: ld returned 1 exit status
make[2]: **\* [../bin/alienrain] Error 1
make[1]: **\* [CMakeFiles/alienrain.dir/all] Error 2
make: **\* [all] Error 2
