### PR TITLE
Replaced "glfw3" with ${GLFW_LIBRARIES}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(COMMON_LIBS sb7 optimized glfw3 debug glfw3_d ${GLFW_LIBRARIES} ${OPENGL_LIB
 elseif (UNIX)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLFW REQUIRED glfw3)
-set(COMMON_LIBS sb7 glfw3 X11 Xrandr Xinerama Xi Xxf86vm Xcursor GL rt dl)
+set(COMMON_LIBS sb7 ${GLFW_LIBRARIES} X11 Xrandr Xinerama Xi Xxf86vm Xcursor GL rt dl)
 else()
 set(COMMON_LIBS sb7)
 endif()


### PR DESCRIPTION
GLFW was not being pointed to correctly on linux. After pkg-config, the variable GLFW_LIBRARIES is set to the correct name of the package on the system, which for me at least was "glfw" instead of "glfw3". Minor change, but it should build on linux now.
