### PR TITLE
docs: fix simple typo, uesful -> useful

### DIFF
--- a/extern/glfw-3.0.4/examples/splitview.c
+++ b/extern/glfw-3.0.4/examples/splitview.c
@@ -2,7 +2,7 @@
 // This is an example program for the GLFW library
 //
 // The program uses a "split window" view, rendering four views of the
-// same scene in one window (e.g. uesful for 3D modelling software). This
+// same scene in one window (e.g. useful for 3D modelling software). This
 // demo uses scissors to separete the four different rendering areas from
 // each other.
 //


### PR DESCRIPTION
There is a small typo in extern/glfw-3.0.4/examples/splitview.c.

Should read `useful` rather than `uesful`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md