### PR TITLE
typo in HOWTOBUILD.txt

### DIFF
--- a/HOWTOBUILD.txt
+++ b/HOWTOBUILD.txt
@@ -55,7 +55,7 @@ the a snapshot of GLFW included in the archive, if you wish, but pre-compiled
 packages should be available through package management on most distributions.
 
 Once you have everything, you should enter the "build" directory in the source
-arvhive and issue:
+archive and issue:
 
     cmake ..
     make

--- a/HOWTOBUILD.txt
+++ b/HOWTOBUILD.txt
@@ -1,17 +1,17 @@
 OpenGL SuperBible 7th Edition Examples - How to Build
 =====================================================
 
-This source code archive uses CMake to build. The samples also use GLFW library, a
-snapshot of which is included in the `extern` folder. It's also possible to use a different
-copy of GLFW if desired, but that's an excercise for you. Instructions for each supported
-platform are as follows:
+This source code archive uses CMake to build. The samples also use GLFW
+library, a snapshot of which is included in the `extern` folder. It's also
+possible to use a different copy of GLFW if desired, but that's an
+excercise for you. Instructions for each supported platform are as follows:
 
 Windows / Microsoft Visual Studio 2013
 --------------------------------------
 
 Install CMake. Windows binaries are available from http://www.cmake.org/.
-Ensure that CMake is in your path.
-Open a command prompt and change to the directory where you've checked out the code.
+Ensure that CMake is in your path. Open a command prompt and change to the
+directory where you've checked out the code.
 
 ### Build GLFW
 
@@ -22,12 +22,15 @@ GLFW directory in `extern/glfw-3.0.4`, and type:
 
 (Yes, that's not a mistake - Visual Studio 12 is 2013)
 
-Open the resulting GLFW.sln file in Visual Studio and build both the debug and release configurations.
+Open the resulting GLFW.sln file in Visual Studio and build both the debug
+and release configurations.
 
 Copy and rename the resulting glfw3 libraries:
 
-* Copy `glfw-3.0.4/src/Debug/glfw3.lib` into the `lib` directory and **rename it to glfw3_d.lib**.
-* Copy `glf3-3.0.4/src/Release/glfw3.lib` into the `lib` directory but don't rename it.
+* Copy `glfw-3.0.4/src/Debug/glfw3.lib` into the `lib` directory and
+  rename it to glfw3_d.lib**.
+* Copy `glf3-3.0.4/src/Release/glfw3.lib` into the `lib` directory but
+  don't rename it.
 
 ### Build the samples
 
@@ -50,12 +53,13 @@ Debian-based distributions (such as Ubuntu and Mint):
     sudo apt-get install cmake
 
 You'll also need to satisfy dependencies. In particular, you'll need GL and
-GLX headers and libs (generally included in Mesa packages), and GLFW. You can use
-the a snapshot of GLFW included in the archive, if you wish, but pre-compiled
-packages should be available through package management on most distributions.
+GLX headers and libs (generally included in Mesa packages), and GLFW. You
+can use the a snapshot of GLFW included in the archive, if you wish, but
+pre-compiled packages should be available through package management on
+most distributions.
 
-Once you have everything, you should enter the "build" directory in the source
-archive and issue:
+Once you have everything, you should enter the "build" directory in the
+source archive and issue:
 
     cmake ..
     make
@@ -83,6 +87,9 @@ Running the samples
 *This part is really important. Please read it!*
 
 Most of the samples require some media files. The media files package is a
-separate download available from http://www.openglsuperbible.com and is
-rougly 100MB of textures, object files and shader code. Unpack the archive
-to the bin/media directory before trying to run these samples.
+separate download available from:
+
+    http://openglsuperbible.com/files/superbible7-media.zip
+
+...and is roughly 100MB of textures, object files and shader code. Unpack
+the archive to the bin/media directory before trying to run these samples.


### PR DESCRIPTION
Noticed a typo on HOWTOBUILD.txt. 

Also noticed that the web site appears to be partially broken at the
moment. This is particularly unfortunate given that superbible7-media.zip
is a necessary component.

Luckily it's available via archive.org, but not everyone will think of that.